### PR TITLE
feat: add GetRequestIDFromContext

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -254,7 +254,12 @@ func NewWithConfig(logger *slog.Logger, config Config) func(http.Handler) http.H
 
 // GetRequestID returns the request identifier
 func GetRequestID(r *http.Request) string {
-	requestID := r.Context().Value(requestIDCtxKey)
+	return GetRequestIDFromContext(r.Context())
+}
+
+// GetRequestIDFromContext returns the request identifier from the context
+func GetRequestIDFromContext(ctx context.Context) string {
+	requestID := ctx.Value(requestIDCtxKey)
 	if id, ok := requestID.(string); ok {
 		return id
 	}


### PR DESCRIPTION
Hello !
I added a function to get the request ID from the context directly.

Currently I'm using this workaround:
```go
fakeRequest := (&http.Request{}).WithContext(ctx)
sloghttp.GetRequestID(fakeRequest)
```

`GetRequestIDFromContext` makes it more straightforward
 