### PR TITLE
fix: recovery handler suppresses http.ErrAbortHandler

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -9,7 +9,7 @@ import (
 func Recovery(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
-			if err := recover(); err != nil {
+			if err := recover(); err != nil && err != http.ErrAbortHandler {
 				buf := make([]byte, 2048)
 				n := runtime.Stack(buf, false)
 				buf = buf[:n]


### PR DESCRIPTION
@samber I've stumbled upon recovered panic of the [`http.ErrAbortHandler`](https://pkg.go.dev/net/http#ErrAbortHandler) recently using the `Recovery` middleware.

According to previous [discussion](https://github.com/golang/go/issues/28239) in the Go issue tracker, the recommendation is to suppress this error and avoid printing a stacktrace.

