### PR TITLE
fix: avoid infinite recursion when recording body with Readfrom

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -81,7 +81,8 @@ func (w *bodyWriter) ReadFrom(r io.Reader) (int64, error) {
 			return n, err
 		}
 	}
-	return io.Copy(w, r)
+	// hide ReaderFrom interface to avoid infinite recursion
+	return io.Copy(struct{ io.Writer }{w}, r)
 }
 
 // Unwrap implements the ability to use underlying http.ResponseController

--- a/dump_test.go
+++ b/dump_test.go
@@ -1,0 +1,52 @@
+package sloghttp
+
+import (
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBodyWriter_ReadFrom(t *testing.T) {
+	content := "<!DOCTYPE html><html lang=\"en\">"
+
+	tests := []struct {
+		name       string
+		recordBody bool
+	}{
+		{"with record body", true},
+		{"without record body", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			bw := newBodyWriter(w, 16, tt.recordBody)
+			// wrap in simpleReader to use io.ReadFrom instead of io.WriteTo to check for infinite recursion
+			reader := simpleReader{strings.NewReader(content)}
+
+			n, err := bw.ReadFrom(reader)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			expectedN := len(content)
+			if n != int64(expectedN) {
+				t.Errorf("expected n to be %d, got %d", expectedN, n)
+			}
+			if bw.bytes != expectedN {
+				t.Errorf("expected bytes to be %d, got %d", expectedN, bw.bytes)
+			}
+			if w.Body.String() != content {
+				t.Errorf("expected response body to be %q, got %q", content, w.Body.String())
+			}
+			if tt.recordBody && bw.body.String() != content[:16] {
+				t.Errorf("expected captured body to be truncated to %q, got %q", content[:16], bw.body.String())
+			}
+		})
+	}
+}
+
+type simpleReader struct {
+	io.Reader
+}


### PR DESCRIPTION
See #17